### PR TITLE
Changed package.json with new scripts syntax for test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "scripts": {
     "preinstall": "npm i -g yo generator-js-type@0.0.4",
-    "test": "./node_modules/mocha/bin/mocha test/*_spec.js"
+    "test": "mocha test/*_spec.js"
   }
 }


### PR DESCRIPTION
If **mocha** it's already a development dependency, you don't need to include it's full absolute path.
Calling `mocha` will go for the local node_modules folder already and not the global.
